### PR TITLE
Every icon is a Material Symbol, every chevron is the house chevron, and none of them has a box

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,6 @@
     <script>
       (function(){var t=localStorage.getItem('wm-theme')||'auto';document.documentElement.dataset.theme=t;})();
     </script>
-    <!-- Material Symbols, all four axes. NOT subsetted yet, on purpose: `icon_names` is
-         how this ships eventually (24 icons = 22KB against 3.97MB), but a subset that
-         drifts from the code renders the missing ligature as its own name in plain text,
-         so the list has to be generated from usage before it can be trusted. Full font
-         until then -- correct at any size, expensive, and obviously so. -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MZ4M1P8P1P"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,14 @@
     <script>
       (function(){var t=localStorage.getItem('wm-theme')||'auto';document.documentElement.dataset.theme=t;})();
     </script>
+    <!-- Material Symbols, all four axes. NOT subsetted yet, on purpose: `icon_names` is
+         how this ships eventually (24 icons = 22KB against 3.97MB), but a subset that
+         drifts from the code renders the missing ligature as its own name in plain text,
+         so the list has to be generated from usage before it can be trusted. Full font
+         until then -- correct at any size, expensive, and obviously so. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MZ4M1P8P1P"></script>
     <script>

--- a/src/App.css
+++ b/src/App.css
@@ -697,11 +697,27 @@
   margin-bottom: 0.6em;
 }
 
-.para-block:last-child {
+/* The wrapper exists so the style rail can sit BESIDE the editable element rather than
+   inside it: anything inside a contentEditable is counted by the caret helpers and is
+   typeable. Relative, because it is what BlockStyleRail positions against -- without it
+   the rail resolves to .preview-paragraph and every block's rail stacks at the top of the
+   column instead of beside its own paragraph. */
+.para-block-wrap { position: relative; }
+
+/* THROUGH THE WRAPPER, not the block. Every one of these was written when the blocks were
+   siblings of each other; wrapping each block to hang the style rail off it broke all
+   three at once, silently and in the same direction -- everything collapsed to zero.
+   `:last-child` matched EVERY block, because each is now the only child of its own
+   wrapper, so the "no margin after the last one" rule zeroed all of them. And
+   `.para-block--p + .para-block--p` matched nothing, because no two blocks are siblings
+   any more, so paragraphs lost the space between them.
+   The wrapper is the thing in the flow now, so the flow rules live on it and reach the
+   block through :has(). */
+.para-block-wrap:last-child .para-block {
   margin-bottom: 0;
 }
 
-.para-block--p + .para-block--p {
+.para-block-wrap:has(.para-block--p) + .para-block-wrap:has(.para-block--p) .para-block {
   margin-top: 0.4em;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -693,40 +693,35 @@
   position: relative;
 }
 
-.para-block {
-  margin-bottom: 0.6em;
-}
+/* ── Paragraph block rhythm ───────────────────────────────────────────────────
+   ONE GAP, the same between every pair of blocks whatever their levels. It was four
+   different numbers before -- 0.6em below each block, 0.4em extra between paragraphs,
+   1em above a heading, 0.2em below one -- and every one of them was in `em`, so it
+   scaled with the block's OWN size: a 57px h1 reserved 57px above itself and a 22px h3
+   reserved 22. The bigger the heading, the bigger its gap, which is backwards. A heading
+   already announces itself by being large; the space is there to part it from the block
+   above, which has not changed size.
+   So: rem, not em, and one value. The only exception is the top of the document, which is
+   a different event from one block following another. */
+.para-block { margin: 0; }
+
+.para-block-wrap + .para-block-wrap { margin-top: 0.75rem; }
+
+.para-block-wrap:first-child .para-block { margin-top: 3rem; }
 
 /* The wrapper exists so the style rail can sit BESIDE the editable element rather than
    inside it: anything inside a contentEditable is counted by the caret helpers and is
    typeable. Relative, because it is what BlockStyleRail positions against -- without it
    the rail resolves to .preview-paragraph and every block's rail stacks at the top of the
-   column instead of beside its own paragraph. */
+   column instead of beside its own paragraph.
+
+   The flow rules live on the WRAPPER, not the block, and that is not cosmetic: wrapping
+   each block broke every sibling and child selector at once, silently and all in the same
+   direction. `.para-block:last-child` began matching every block, because each is now the
+   only child of its own wrapper; `.para-block--p + .para-block--p` matched nothing,
+   because no two blocks are siblings any more. Everything collapsed to zero, which reads
+   as a deliberate rhythm rather than as breakage. */
 .para-block-wrap { position: relative; }
-
-/* THROUGH THE WRAPPER, not the block. Every one of these was written when the blocks were
-   siblings of each other; wrapping each block to hang the style rail off it broke all
-   three at once, silently and in the same direction -- everything collapsed to zero.
-   `:last-child` matched EVERY block, because each is now the only child of its own
-   wrapper, so the "no margin after the last one" rule zeroed all of them. And
-   `.para-block--p + .para-block--p` matched nothing, because no two blocks are siblings
-   any more, so paragraphs lost the space between them.
-   The wrapper is the thing in the flow now, so the flow rules live on it and reach the
-   block through :has(). */
-.para-block-wrap:last-child .para-block {
-  margin-bottom: 0;
-}
-
-.para-block-wrap:has(.para-block--p) + .para-block-wrap:has(.para-block--p) .para-block {
-  margin-top: 0.4em;
-}
-
-.para-block--h1,
-.para-block--h2,
-.para-block--h3 {
-  margin-top: 1em;
-  margin-bottom: 0.2em;
-}
 
 /* Paragraph menu-target highlight now uses the shared edit-rail (edit-rail--target);
    see wm-primitives/src/editRail.css. The old offset outline was retired. */

--- a/src/App.css
+++ b/src/App.css
@@ -1,15 +1,18 @@
 /* ── Theme toggle ────────────────────────────────────────────────────────── */
-/* The control itself is the house Toggle Group (shared/src/toggleGroup.css). What stays
-   here is placement: a fixed affordance that recedes until you reach for it. */
+/* Three marks now, not the house Toggle Group: brightness_auto / light_mode / dark_mode,
+   each a .wm-icon-btn that draws nothing. What stays here is placement and the row.
+   The blanket `opacity: .6` is gone with the lozenge -- it dimmed the CHOSEN option as
+   much as the other two, which fought the ink ladder the marks now use to say which is
+   on. The marks recede on their own: ink-faint at rest is quieter than .6 ever was. */
 #theme-toggle {
   position: fixed;
   top: 20px;
   right: 20px;
   z-index: 100;
-  opacity: 0.6;
-  transition: opacity var(--dur-fast, 140ms);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-01, 4px);
 }
-#theme-toggle:hover { opacity: 1; }
 
 /* ── Layout ──────────────────────────────────────────────────────────────── */
 .layout {
@@ -263,20 +266,36 @@
   gap: 4px;
 }
 
+/* THE ROW IS THE BAR. The panel toggle used to be a sibling sitting beside the mode
+   button with a 4px gap, which read as one pill and a loose mark next to it -- and once
+   the mark lost its box there was nothing tying the two together at all.
+   So the fill and the radius move up to the row: the label and the toggle are inside one
+   bar, which is what they always were logically -- a mode, and the way into its settings.
+   Nesting the toggle inside .mode-btn would be the other fix and is not available: a
+   button inside a button is invalid, and the outer one would swallow its clicks. */
 .mode-btn-row {
   display: flex;
   align-items: stretch;
-  gap: 4px;
+  gap: 0;
+  border-radius: var(--radius);
+  transition: background var(--dur-fast, 140ms);
 }
+.mode-btn-row:hover,
+.mode-btn-row:has(.mode-btn.active) { background: var(--bg-elevated); }
 
 .mode-btn-row .mode-btn {
   flex: 1;
 }
+/* Inside the bar the button paints nothing -- the bar is doing it, and two nested fills
+   read as a pill inside a pill. */
+.mode-btn-row .mode-btn,
+.mode-btn-row .mode-btn:hover,
+.mode-btn-row .mode-btn.active { background: transparent; }
 
 .mode-btn-row .styles-toggle-btn {
   width: 30px;
   height: auto;
-  border-radius: var(--radius);
+  border-radius: 0;
   flex-shrink: 0;
 }
 
@@ -432,35 +451,34 @@
   gap: 3px;      /* 4 -> 3: five buttons in the width three used to have */
 }
 
+/* NO BOX. This drew a 28px bordered square with its own fill, and the state lived in it
+   -- border-color and background -- while the mark inside barely moved. Beside the four
+   alignments, which lost theirs when they became Material Symbols, the reset was the one
+   button in the row still wearing chrome.
+   The mark carries the state now: Icon moves ink and weight together, so active is bolder
+   as well as brighter. What is left here is the target, and it draws nothing. */
 .align-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  /* 28, not 32: the row now carries five — reset plus four alignments. */
+  /* Still 28: the target does not shrink because the box left. */
   width: 28px;
   height: 28px;
-  border-radius: var(--radius);
-  background: var(--bg-elevated);
-  color: var(--text-dim);
-  border: 1px solid var(--border);
-  transition: background var(--dur-fast, 140ms), color var(--dur-fast, 140ms), border-color var(--dur-fast, 140ms);
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 0;
+  color: inherit;
 }
 
-.align-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-muted);
-}
+/* Hover and active are the MARK's now -- icon.css owns them, on ink and weight together.
+   Nothing here paints a background or a border for a state any more.
+   .reset-clean stays: "nothing to reset" is a real third state, and it is exactly what
+   Icon calls `off`. Left as an opacity here so the existing className keeps working;
+   the row should pass state="off" to Icon instead once the call sites move. */
+.align-btn.reset-clean { opacity: 0.4; }
 
-.align-btn.active {
-  background: var(--bg-hover);
-  color: var(--text);
-  border-color: var(--text-muted);
-}
-
-.align-btn.reset-clean {
-  color: var(--text-dim);
-  opacity: 0.4;
-}
+@media (pointer: coarse) { .align-btn { width: 44px; height: 44px; } }
 
 /* ── Glyph set buttons ───────────────────────────────────────────────────── */
 .glyph-set-group {

--- a/src/App.css
+++ b/src/App.css
@@ -396,20 +396,34 @@
   font-size: var(--type-ui-size, 0.75rem);
   outline: none;
   cursor: pointer;
-  appearance: auto;
-  -webkit-appearance: auto;
+
+  /* OUR CHEVRON, NOT THE PLATFORM'S. `appearance: auto` let the OS draw the dropdown
+     arrow, so the one mark in this panel nobody could restyle was also the one matching
+     nothing -- and under 768px a media query swapped in a hand-rolled data-URI chevron at
+     stroke 1.5 with a hardcoded #888, so it did not even match itself across viewports.
+     The arrow is a real <Icon> in .instance-select-wrap now, which is the only way it can
+     be the same mark as every other chevron: a data: URI cannot read currentColor, so as
+     a background-image it is a fixed grey that ignores the theme and the ink ladder, and
+     a mask on the <select> itself would mask the option text along with it. */
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: var(--spacing-06, 24px);
 }
 
-@media (max-width: 768px) {
-  .instance-select {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 8px center;
-    padding-right: var(--spacing-06, 24px);
-    appearance: none;
-    -webkit-appearance: none;
-  }
+/* The wrapper exists only to hang the arrow off; the select still owns its own box. */
+.instance-select-wrap { position: relative; display: block; }
+.instance-select-wrap .wm-chevron {
+  position: absolute;
+  right: var(--spacing-03, 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  /* The select is what you are clicking; the mark is decoration on top of it. */
+  pointer-events: none;
+  color: var(--text-muted);
 }
+
+/* The narrow-viewport override that used to draw a SECOND chevron here is gone: the rule
+   above is unconditional now, so there is one drawing at every width. */
 
 .instance-select:focus {
   border-color: var(--text-muted);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1473,7 +1473,7 @@ export default function App() {
           {mode === 'paragraph' && (['h1', 'h2', 'h3', 'p']).map(type => (
             <button
               key={type}
-              className={`mobile-sub-btn ${activeParaStyle === type ? 'active' : ''}`}
+              className={`mobile-sub-btn ${effectiveParaStyle === type ? 'active' : ''}`}
               onClick={() => setActiveParaStyle(prev => prev === type ? null : type)}
             >
               {type === 'p' ? 'P' : type.toUpperCase()}
@@ -2699,7 +2699,13 @@ export default function App() {
                       kind: 'axis',
                     })),
                   ],
-                  selected: activeParaStyle === type,
+                  /* effectiveParaStyle, not activeParaStyle: entering paragraph mode
+                     already targets `p` (see the `activeParaStyle ?? 'p'` above), so the
+                     panel has to say so. Highlighting the raw state left every row unlit
+                     while the sidebar was quietly editing the paragraph -- the controls
+                     and the picker disagreed about what was selected, and the picker was
+                     the one that was wrong. */
+                  selected: effectiveParaStyle === type,
                 }
               })}
             />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import {
   AxisSlider as SliderRow,
   Icon,
   makeGlyphSets, parseCmapRanges, isSupported,
-  nbMinus, EditableTextBlock, GlyphPicker, measureGlyphMetrics, enumerateCmap,
+  nbMinus, EditableTextBlock, BlockStyleRail, GlyphPicker, measureGlyphMetrics, enumerateCmap,
   FLATTERSATZ_DEFAULTS as FIT_DEFAULTS,
   FittingControls, fittingMode, AlignmentButtons, FittedParagraph,
   PARA_STYLE_DEFAULTS, fitOptionsFor,
@@ -2267,8 +2267,20 @@ export default function App() {
         {fontName && mode === 'paragraph' && (
           <div className="preview-paragraph" style={{ maxWidth: `${measure}px` }}>
               {blocks.map((block, i) => (
+                /* The rail is a SIBLING of the editable element, not a child: anything
+                   inside a contentEditable is counted by the caret helpers and is
+                   typeable. The wrapper is what the rail is positioned against. */
+                <div className="para-block-wrap" key={block.id}>
+                {focusedBlockId === block.id && (
+                  <BlockStyleRail
+                    value={block.type}
+                    onChange={k => {
+                      setBlocks(prev => prev.map(x => x.id === block.id ? { ...x, type: k } : x))
+                      requestAnimationFrame(() => blockRefs.current[block.id]?.focus())
+                    }}
+                  />
+                )}
                 <EditableTextBlock
-                  key={block.id}
                   value={block.text}
                   focused={focusedBlockId === block.id}
                   onFocusChange={f => setFocusedBlockId(cur => f ? block.id : (cur === block.id ? null : cur))}
@@ -2297,6 +2309,7 @@ export default function App() {
                     )
                   }}
                 />
+                </div>
               ))}
               {/* The tail of a part-loaded work fades instead of stopping dead, so the
                   cut reads as "more of this" rather than the end of the specimen. The

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import {
   AxisSlider as SliderRow,
   Icon,
   makeGlyphSets, parseCmapRanges, isSupported,
-  nbMinus, EditableTextBlock, BlockStyleRail, GlyphPicker, measureGlyphMetrics, enumerateCmap,
+  nbMinus, EditableTextBlock, BlockStyleRail, Chevron, GlyphPicker, measureGlyphMetrics, enumerateCmap,
   FLATTERSATZ_DEFAULTS as FIT_DEFAULTS,
   FittingControls, fittingMode, AlignmentButtons, FittedParagraph,
   PARA_STYLE_DEFAULTS, fitOptionsFor,
@@ -1564,7 +1564,12 @@ export default function App() {
         onClick={() => setDesktopSidebarOpen(p => !p)}
         title={desktopSidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
       >
-        {desktopSidebarOpen ? <Icon name="arrow_back_ios_new" /> : <Icon name="arrow_forward_ios" />}
+        {/* The house Chevron, rotated, not arrow_back_ios_new: a chevron is a chevron
+            wherever it appears, and Material's has flat ends, a steeper angle and a 20px
+            opsz floor. Material keeps the SYMBOLS -- pilcrow, aligns, reset, theme -- which
+            are never asked to be 6px. */}
+        <Chevron dir={-1} width={12} height={7}
+          className={desktopSidebarOpen ? 'chev-left' : 'chev-right'} />
       </button>
       {!mobileSidebarOpen && (
         <button className="mobile-sidebar-lift-tab" onClick={() => setMobileSidebarOpen(true)}>
@@ -1573,7 +1578,7 @@ export default function App() {
       )}
       <aside className={`sidebar${mobileSidebarOpen ? '' : ' mobile-collapsed'}${desktopSidebarOpen ? '' : ' desktop-collapsed'}`}>
         <button className="mobile-sidebar-handle" onClick={() => setMobileSidebarOpen(false)}>
-          <Icon name="keyboard_arrow_down" />
+          <Chevron dir={-1} width={12} height={7} />
         </button>
         {/* Logo */}
         <div className="sidebar-logo">
@@ -1826,6 +1831,7 @@ export default function App() {
             )}
           </div>
           {isFamily && (
+            <span className="instance-select-wrap">
             <select
               className="instance-select"
               value={scopedWeight ?? ''}
@@ -1836,6 +1842,11 @@ export default function App() {
                 <option key={s.key} value={s.key}>{s.label}</option>
               ))}
             </select>
+              {/* The HOUSE chevron, not keyboard_arrow_down: Material's has flat ends and a
+      steeper angle than the stepper chevrons beside the numbers, and those are
+      the ones that have to be right. See shared/src/Chevron.tsx. */}
+  <Chevron dir={-1} width={12} height={7} />
+            </span>
           )}
           {(italicFontFace || variationAxes.some(a => a.tag === 'ital')) && (() => {
             const italAxis = variationAxes.find(a => a.tag === 'ital')
@@ -1864,6 +1875,7 @@ export default function App() {
               The featureStr/paraStyles ss04/ss05 plumbing is still in place if
               a real one is ever built. */}
           {ttcFonts.length > 1 && (
+            <span className="instance-select-wrap">
             <select
               className="instance-select"
               value={ttcIndex}
@@ -1873,6 +1885,11 @@ export default function App() {
                 <option key={i} value={i}>{name}</option>
               ))}
             </select>
+              {/* The HOUSE chevron, not keyboard_arrow_down: Material's has flat ends and a
+      steeper angle than the stepper chevrons beside the numbers, and those are
+      the ones that have to be right. See shared/src/Chevron.tsx. */}
+  <Chevron dir={-1} width={12} height={7} />
+            </span>
           )}
           {namedInstances.length > 0 && (() => {
             const currentCoords = effectiveScaleStep
@@ -1902,6 +1919,7 @@ export default function App() {
               }
             }
             return (
+              <span className="instance-select-wrap">
               <select
                 className="instance-select"
                 value={activeInst?.name ?? ''}
@@ -1912,6 +1930,11 @@ export default function App() {
                   <option key={inst.name} value={inst.name}>{inst.name}</option>
                 ))}
               </select>
+                {/* The HOUSE chevron, not keyboard_arrow_down: Material's has flat ends and a
+      steeper angle than the stepper chevrons beside the numbers, and those are
+      the ones that have to be right. See shared/src/Chevron.tsx. */}
+  <Chevron dir={-1} width={12} height={7} />
+              </span>
             )
           })()}
           {/* Size/Tracking/Leading are per-step in Type Scale, so hide them there */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import {
   placeCaretAtEnd as placeCursorAtEnd,
   splitInlineMarkup, isPlainRun,
   AxisSlider as SliderRow,
+  Icon,
   makeGlyphSets, parseCmapRanges, isSupported,
   nbMinus, EditableTextBlock, GlyphPicker, measureGlyphMetrics, enumerateCmap,
   FLATTERSATZ_DEFAULTS as FIT_DEFAULTS,
@@ -1448,13 +1449,13 @@ export default function App() {
 
       {/* Mobile tab bar */}
       <nav className="mobile-tabs">
-        {isCalcom && <button className={`mobile-tab ${mode === 'calcom' ? 'active' : ''}`} onClick={() => setMode('calcom')}><CalIcon /> cal.com/peer</button>}
-        {isCalcom && <button className={`mobile-tab ${mode === 'coss' ? 'active' : ''}`} onClick={() => setMode('coss')}><CalIcon /> booking events</button>}
-        <button className={`mobile-tab ${mode === 'big' ? 'active' : ''}`} onClick={() => setMode('big')}><BigIcon className={mode === 'big' ? 'aa-animated' : undefined} /> Big Word</button>
-        <button className={`mobile-tab ${mode === 'paragraph' ? 'active' : ''}`} onClick={() => setMode('paragraph')}><ParaIcon /> Paragraph</button>
-        <button className={`mobile-tab ${mode === 'ui' ? 'active' : ''}`} onClick={() => setMode('ui')}><CalIcon /> UI</button>
-        <button className={`mobile-tab ${mode === 'scale' ? 'active' : ''}`} onClick={() => setMode('scale')}><ScaleIcon /> Type Scale</button>
-        <button className={`mobile-tab ${mode === 'glyphs' ? 'active' : ''}`} onClick={() => setMode('glyphs')}><GlyphIcon /> Glyphs</button>
+        {isCalcom && <button className={`mobile-tab ${mode === 'calcom' ? 'active' : ''}`} onClick={() => setMode('calcom')}><Icon name="calendar_month" /> cal.com/peer</button>}
+        {isCalcom && <button className={`mobile-tab ${mode === 'coss' ? 'active' : ''}`} onClick={() => setMode('coss')}><Icon name="calendar_month" /> booking events</button>}
+        <button className={`mobile-tab ${mode === 'big' ? 'active' : ''}`} onClick={() => setMode('big')}><Icon name="insert_text" className={mode === 'big' ? 'aa-animated' : undefined} /> Big Word</button>
+        <button className={`mobile-tab ${mode === 'paragraph' ? 'active' : ''}`} onClick={() => setMode('paragraph')}><Icon name="format_paragraph" /> Paragraph</button>
+        <button className={`mobile-tab ${mode === 'ui' ? 'active' : ''}`} onClick={() => setMode('ui')}><Icon name="calendar_month" /> UI</button>
+        <button className={`mobile-tab ${mode === 'scale' ? 'active' : ''}`} onClick={() => setMode('scale')}><Icon name="text_fields" /> Type Scale</button>
+        <button className={`mobile-tab ${mode === 'glyphs' ? 'active' : ''}`} onClick={() => setMode('glyphs')}><Icon name="grid_view" /> Glyphs</button>
       </nav>
 
       {/* Mobile sub-bar: context-sensitive chips */}
@@ -1493,7 +1494,7 @@ export default function App() {
               className={`mobile-multi-btn ${scaleMultiSelectMode ? 'active' : ''}`}
               onClick={() => setScaleMultiSelectMode(p => !p)}
               title="Select multiple steps"
-            ><MultiSelectIcon /></button>
+            ><Icon name="forms_add_on" /></button>
           )}
           {mode === 'scale' && visibleScaleSteps.map(step => {
             const isSelected = selectedScaleSteps.includes(step.key) || activeScaleStep === step.key
@@ -1563,16 +1564,16 @@ export default function App() {
         onClick={() => setDesktopSidebarOpen(p => !p)}
         title={desktopSidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
       >
-        {desktopSidebarOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+        {desktopSidebarOpen ? <Icon name="arrow_back_ios_new" /> : <Icon name="arrow_forward_ios" />}
       </button>
       {!mobileSidebarOpen && (
         <button className="mobile-sidebar-lift-tab" onClick={() => setMobileSidebarOpen(true)}>
-          <ChevronUpIcon />
+          <Icon name="keyboard_arrow_up" />
         </button>
       )}
       <aside className={`sidebar${mobileSidebarOpen ? '' : ' mobile-collapsed'}${desktopSidebarOpen ? '' : ' desktop-collapsed'}`}>
         <button className="mobile-sidebar-handle" onClick={() => setMobileSidebarOpen(false)}>
-          <ChevronDownIcon />
+          <Icon name="keyboard_arrow_down" />
         </button>
         {/* Logo */}
         <div className="sidebar-logo">
@@ -1628,7 +1629,7 @@ export default function App() {
             {isCalcom && (
               <div className="mode-btn-row">
                 <ModeBtn active={mode === 'calcom'} onClick={() => setMode('calcom')}>
-                  <CalIcon /> cal.com/peer
+                  <Icon name="calendar_month" /> cal.com/peer
                 </ModeBtn>
                 {fontName && mode === 'calcom' && (
                   <button
@@ -1637,7 +1638,7 @@ export default function App() {
                     title="Type roles panel"
                     onClick={() => setCalcomPanelOpen(p => !p)}
                   >
-                    <SlidersIcon />
+                    <Icon name="discover_tune" />
                   </button>
                 )}
               </div>
@@ -1645,7 +1646,7 @@ export default function App() {
             {isCalcom && (
               <div className="mode-btn-row">
                 <ModeBtn active={mode === 'coss'} onClick={() => setMode('coss')}>
-                  <CalIcon /> booking events
+                  <Icon name="calendar_month" /> booking events
                 </ModeBtn>
                 {fontName && mode === 'coss' && (
                   <button
@@ -1654,17 +1655,17 @@ export default function App() {
                     title="Type roles panel"
                     onClick={() => setCossPanelOpen(p => !p)}
                   >
-                    <SlidersIcon />
+                    <Icon name="discover_tune" />
                   </button>
                 )}
               </div>
             )}
             <ModeBtn active={mode === 'big'} onClick={() => setMode('big')}>
-              <BigIcon className={mode === 'big' ? 'aa-animated' : undefined} /> Big Word
+              <Icon name="insert_text" className={mode === 'big' ? 'aa-animated' : undefined} /> Big Word
             </ModeBtn>
             <div className="mode-btn-row">
               <ModeBtn active={mode === 'paragraph'} onClick={() => setMode('paragraph')}>
-                <ParaIcon /> Paragraph
+                <Icon name="format_paragraph" /> Paragraph
               </ModeBtn>
               {fontName && mode === 'paragraph' && (
                 <button
@@ -1673,16 +1674,16 @@ export default function App() {
                   title="Styles panel"
                   onClick={() => setParaStylesPanelOpen(p => !p)}
                 >
-                  <SlidersIcon />
+                  <Icon name="discover_tune" />
                 </button>
               )}
             </div>
             <ModeBtn active={mode === 'ui'} onClick={() => setMode('ui')}>
-              <CalIcon /> UI
+              <Icon name="calendar_month" /> UI
             </ModeBtn>
             <div className="mode-btn-row">
               <ModeBtn active={mode === 'scale'} onClick={() => setMode('scale')}>
-                <ScaleIcon /> Type Scale
+                <Icon name="text_fields" /> Type Scale
               </ModeBtn>
               {fontName && mode === 'scale' && (
                 <button
@@ -1691,12 +1692,12 @@ export default function App() {
                   title="Scale steps panel"
                   onClick={() => setScaleStepsPanelOpen(p => !p)}
                 >
-                  <SlidersIcon />
+                  <Icon name="discover_tune" />
                 </button>
               )}
             </div>
             <ModeBtn active={mode === 'glyphs'} onClick={() => setMode('glyphs')}>
-              <GlyphIcon /> Glyphs
+              <Icon name="grid_view" /> Glyphs
             </ModeBtn>
           </div>
         </div>
@@ -1812,7 +1813,7 @@ export default function App() {
                       }
                       setFit(FIT_DEFAULTS)
                     }}
-                  ><ResetIcon /></button>
+                  ><Icon name="settings_backup_restore" /></button>
                 )
               })()}
               {/* In paragraph mode alignment belongs to the SELECTED style, the same as
@@ -2082,7 +2083,7 @@ export default function App() {
                           setAxisValues(defaults)
                         }
                       }}
-                    ><ResetIcon /></button>
+                    ><Icon name="settings_backup_restore" /></button>
                   )
                 })()}
               </div>
@@ -2559,7 +2560,7 @@ export default function App() {
                 className={`scale-multi-btn ${scaleMultiSelectMode ? 'active' : ''}`}
                 onClick={() => setScaleMultiSelectMode(p => !p)}
                 title="Select multiple steps"
-              ><MultiSelectIcon /></button>
+              ><Icon name="forms_add_on" /></button>
             </div>
             {/* migrated to shared StyleScopeList (multi-select); keeps this panel's own
                 trigger/positioning and the shift-range / multi-mode selection logic */}
@@ -2656,7 +2657,19 @@ export default function App() {
                 const fvs = Object.entries(merged).map(([t, v]) => `"${t}" ${v}`).join(', ') || 'normal'
                 return {
                   id: type,
-                  label: type === 'p' ? 'Paragraph' : `Heading ${type[1]}`,
+                  /* The MARK names the level now -- format_h1/h2/h3, and the same pilcrow
+                     the Paragraph preview mode uses -- which frees the label to stop
+                     being the words "Heading 1" and become a specimen instead. */
+                  icon: type === 'p' ? 'format_paragraph' : `format_h${type[1]}`,
+                  /* "Rag" rather than "Heading 1": the mark beside it already says which
+                     level this is, so the label is free to be a specimen -- ascender,
+                     descender, round and diagonal in four characters.
+                     Still CLAMPED to 22px, not set at the style's real size. Real size was
+                     tried and taken back: at 57px the h1 row is taller than the other
+                     three put together, so the list stops being a list of four choices and
+                     becomes one big word with three footnotes. The size is already in the
+                     chip, stated exactly; the specimen is here to show the FACE. */
+                  label: 'Rag',
                   labelStyle: {
                     fontFamily: fontFace ? `"${fontFace.family}"` : 'serif',
                     fontStyle,
@@ -3222,6 +3235,11 @@ function CossPreview({ roleStyle, activeRole, onRoleClick }) {
 }
 
 // ── Theme Toggle ──────────────────────────────────────────────────────────────
+// Three marks, not a segmented lozenge of three words. The lozenge spelled Auto / Light /
+// Dark and drew a pill around whichever was on, which is a lot of chrome to say a thing
+// each icon says by itself -- and it read as a control ABOUT the page rather than part of
+// it. The state is the mark's own now, as everywhere else: ink and GRAD together.
+const THEME_ICON = { auto: 'brightness_auto', light: 'light_mode', dark: 'dark_mode' }
 function ThemeToggle() {
   const [theme, setTheme] = useState(() => localStorage.getItem('wm-theme') || 'auto')
   const apply = (t) => {
@@ -3230,10 +3248,21 @@ function ThemeToggle() {
     document.documentElement.dataset.theme = t
   }
   return (
-    <div id="theme-toggle" className="ui-seg" role="group" aria-label="Color scheme">
+    <div id="theme-toggle" className="theme-toggle" role="group" aria-label="Color scheme">
       {['auto', 'light', 'dark'].map(t => (
-        <button key={t} data-mode={t} className={theme === t ? 'active' : ''} onClick={() => apply(t)}>
-          {t.charAt(0).toUpperCase() + t.slice(1)}
+        <button
+          key={t}
+          data-mode={t}
+          /* aria-pressed, which the lozenge never had: it carried state in a className
+             only, so a screen reader heard three buttons and no indication of which was
+             on. */
+          aria-pressed={theme === t}
+          aria-label={`${t.charAt(0).toUpperCase() + t.slice(1)} colour scheme`}
+          title={`${t.charAt(0).toUpperCase() + t.slice(1)}`}
+          className={`wm-icon-btn${theme === t ? ' active' : ''}`}
+          onClick={() => apply(t)}
+        >
+          <Icon name={THEME_ICON[t]} size={20} />
         </button>
       ))}
     </div>
@@ -3241,150 +3270,8 @@ function ThemeToggle() {
 }
 
 // ── Icons ─────────────────────────────────────────────────────────────────────
-function CalIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
-      <rect width="20" height="20" rx="3" ry="3" fill="currentColor" fillOpacity="0.15"/>
-      <path fill="currentColor" d="M5.155 12.422c-.43-.25-.769-.587-1.016-1.012-.247-.425-.371-.893-.371-1.402 0-.515.12-.987.36-1.417.24-.43.574-.77 1.001-1.02.427-.25.914-.375 1.459-.375.405 0 .777.071 1.117.214.34.143.635.358.885.648l-.772.735c-.17-.18-.35-.314-.54-.401-.19-.087-.42-.131-.69-.131-.345 0-.646.076-.904.229-.257.153-.456.361-.596.626-.14.265-.21.562-.21.892 0 .33.07.625.21.885.14.26.341.465.604.615.262.15.568.225.918.225.235 0 .456-.042.664-.128.207-.085.383-.21.529-.375l.795.698c-.22.265-.498.476-.832.633-.335.157-.728.236-1.177.236-.525 0-1.002-.125-1.432-.375ZM9.835 12.516c-.3-.193-.534-.449-.701-.769-.168-.32-.251-.665-.251-1.035 0-.37.084-.715.251-1.035.167-.32.401-.576.701-.769.3-.193.64-.289 1.02-.289.285 0 .542.064.772.191.23.128.383.3.458.514h.052v-.6h1.027v3.974h-1.027v-.585h-.052c-.075.205-.228.371-.458.499-.23.127-.487.191-.772.191-.38 0-.72-.096-1.02-.288Zm1.743-.833c.162-.097.29-.231.382-.401.092-.17.139-.36.139-.57 0-.215-.047-.407-.139-.577-.092-.17-.22-.304-.382-.401-.163-.097-.346-.146-.551-.146-.31 0-.568.106-.772.319-.205.213-.307.478-.307.799 0 .21.046.401.139.574.092.172.221.307.386.405.165.097.35.146.555.146.205 0 .389-.049.551-.146ZM15.391 12.7h-1.057v-.877l.007-4.53h1.058l-.008 5.406Z"/>
-    </svg>
-  )
-}
-function BigIcon({ className }) {
-  return <svg className={className} width="20" height="14" viewBox="0 0 20 14" fill="none"><text x="10" y="12" textAnchor="middle" fontSize="13" fill="currentColor" fontFamily="'Face', system-ui, sans-serif" style={{fontSynthesis:'none'}}>Aa</text></svg>
-}
-function ParaIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="1" y="2" width="12" height="1.5" rx="0.75" fill="currentColor"/>
-      <rect x="1" y="5.5" width="12" height="1.5" rx="0.75" fill="currentColor"/>
-      <rect x="1" y="9" width="8" height="1.5" rx="0.75" fill="currentColor"/>
-    </svg>
-  )
-}
-function GlyphIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="1" y="1" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
-      <rect x="8" y="1" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
-      <rect x="1" y="8" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
-      <rect x="8" y="8" width="5" height="5" rx="1" stroke="currentColor" strokeWidth="1.2"/>
-    </svg>
-  )
-}
-function ScaleIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="1" y="1.5" width="12" height="3" rx="0.75" fill="currentColor"/>
-      <rect x="1" y="6.5" width="12" height="2" rx="0.75" fill="currentColor"/>
-      <rect x="1" y="10.5" width="12" height="1.25" rx="0.625" fill="currentColor"/>
-    </svg>
-  )
-}
-function SlidersIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-      <line x1="1" y1="3" x2="11" y2="3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
-      <circle cx="4" cy="3" r="1.5" fill="currentColor"/>
-      <line x1="1" y1="9" x2="11" y2="9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
-      <circle cx="8" cy="9" r="1.5" fill="currentColor"/>
-    </svg>
-  )
-}
-function AlignLeftIcon() {
-  // One long and one short length across every alignment icon, so the row reads as a set.
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="2" y="1.6" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="5.0" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="8.4" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="11.8" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-    </svg>
-  )
-}
-function AlignCenterIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="2.0" y="1.6" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="4.0" y="5.0" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2.0" y="8.4" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="4.0" y="11.8" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-    </svg>
-  )
-}
-function AlignRightIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="2" y="1.6" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="6" y="5.0" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="8.4" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="6" y="11.8" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-    </svg>
-  )
-}
-function AlignJustifyIcon() {
-  // Three flush lines and a short last one: justification never forces the final line.
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="2" y="1.6" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="5.0" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="8.4" width="10" height="1.2" rx="0.6" fill="currentColor"/>
-      <rect x="2" y="11.8" width="6" height="1.2" rx="0.6" fill="currentColor"/>
-    </svg>
-  )
-}
-function ChevronLeftIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <polyline points="9,2 4,7 9,12" />
-    </svg>
-  )
-}
 
-function ChevronRightIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <polyline points="5,2 10,7 5,12" />
-    </svg>
-  )
-}
 
-function ChevronDownIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <polyline points="3,6 8,11 13,6" />
-    </svg>
-  )
-}
 
-function ChevronUpIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <polyline points="3,10 8,5 13,10" />
-    </svg>
-  )
-}
 
-function MultiSelectIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-      <circle cx="3" cy="4" r="1.5" />
-      <line x1="6.5" y1="4" x2="12" y2="4" />
-      <circle cx="3" cy="10" r="1.5" />
-      <line x1="6.5" y1="10" x2="12" y2="10" />
-    </svg>
-  )
-}
 
-function ResetIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
-      <defs>
-        <style>{`.rst0{stroke-miterlimit:10}.rst0,.rst1{display:none;fill:none;stroke:currentColor;stroke-linecap:round;stroke-width:1.4px}.rst1{stroke-linejoin:round}`}</style>
-      </defs>
-      <path className="rst0" d="M8,2.39906c3.09331,0,5.60094,2.50763,5.60094,5.60094s-2.50763,5.60094-5.60094,5.60094-5.60094-2.50763-5.60094-5.60094c0-1.74259.7958-3.29931,2.04381-4.32656"/>
-      <polyline className="rst1" points="2.04069 3.38941 4.84717 3.38941 4.84717 6.19617"/>
-      <path d="M8,14.2909c-3.47461,0-6.30127-2.81629-6.30127-6.2909,0-2.57326,1.51851-3.90145,2.46222-4.67831.19366-.15897.47817-.12995.6365.06182.15865.19272.10866.45416-.06182.6365-.72266.77296-1.63651,1.99428-1.63651,3.97999,0,2.70215,2.19824,4.91247,4.90088,4.91247,2.70215,0,4.90039-2.21033,4.90039-4.91247,0-2.70264-2.19824-4.90088-4.90039-4.90088-.38672,0-.7002-.31348-.7002-.7002s.31348-.7002.7002-.7002c3.47461,0,6.30078,2.82666,6.30078,6.30127s-2.82617,6.2909-6.30078,6.2909Z"/>
-      <path d="M4.84717,6.89648c-.38672,0-.7002-.31348-.7002-.7002v-2.12169h-2.10645c-.38672,0-.7002-.31032-.7002-.69704s.31348-.68811.7002-.68811h2.80664c.38672,0,.7002.31348.7002.7002v2.80664c0,.38672-.31348.7002-.7002.7002Z"/>
-    </svg>
-  )
-}

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,12 @@
    won over AxisSlider's green `auto` state and left it inheriting the label's grey.
    Anything unlayered still beats all of these, which is where this app's own component
    rules live and where a genuine override belongs. */
-@layer app.base, wm.color, wm.type, wm.controls;
+@layer app.base, wm.color, wm.type, wm.controls, wm.icon;
+/* AFTER the statement above, never before it. A layer's position is fixed when it is
+   first CREATED, so an @import that pulls in `@layer wm.icon` ahead of the ordering line
+   puts wm.icon first and the statement can no longer move it. Same failure that cost an
+   evening when App.jsx was imported before index.css -- see DIAL.md §6. */
+@import '../shared/src/icon.css';
 @import url("https://fonts.googleapis.com/css2?family=Cal+Sans&display=swap");
 
 @font-face {


### PR DESCRIPTION
The testbed for MarkFonts/wm-primitives#10. **Merge that one first** — this app builds against wm-primitives `main` via `--remote`.

## What changed

**13 icons converted, 16 icon functions deleted.** Four of those deletions are `AlignLeft/Center/Right/JustifyIcon`, which rendered **zero times** — the alignment buttons on screen are wm-primitives' own `Fitting.tsx`, so those were duplicates to remove rather than migrate.

**The boxes are gone.** `.align-btn` and `.fit-align-btn` drew 28px bordered squares with their own fill, and the *state* lived in the box — border-colour and background — while the mark inside barely moved. Now the mark is the state: ink and `GRAD` together, so active is denser *and* brighter and survives greyscale. What's left is the target, drawing nothing, 44px on coarse pointers.

**Every chevron is the house chevron.** The three `<select>`s were the worst of it: `appearance: auto` meant the *browser* drew that arrow, so the one mark nobody could restyle was also the one matching nothing — and under 768px a media query swapped in a *third* hand-rolled chevron at stroke 1.5 with a hardcoded `#888`. Five treatments on screen at once, now one.

**The theme toggle is three marks** — `brightness_auto` / `light_mode` / `dark_mode` — not a segmented lozenge of three words, and with `aria-pressed`, which the lozenge never had: it carried state in a className only, so a screen reader heard three buttons and no indication of which was on.

**The panel toggle moved inside its bar.** It was a sibling of the mode button with a 4px gap, which read as one pill and a loose mark beside it — and once the mark lost its box there was nothing tying them together.

**The para-styles rows name their level with a mark** (`format_h1/h2/h3`, and the same pilcrow the Paragraph mode uses) so the label can be a specimen — `Rag` — instead of repeating "Heading 1" next to a chip that already gives the size.

**One gap between every pair of blocks.** It was four numbers, all in `em`, so each scaled with the block's *own* size: a 57px h1 reserved 57px above itself while a 22px h3 reserved 22. The bigger the heading, the bigger its gap, which is backwards.

**The styles picker admits what it targets.** Entering paragraph mode already resolves `activeParaStyle ?? 'p'`, so the sidebar controls were editing the paragraph all along — but the panel highlighted the raw state, which stays `null`. The controls and the picker disagreed, and the picker was wrong.

**`BlockStyleRail` mounted** beside the focused block, as a sibling of the editable element — anything *inside* a contentEditable is counted by the caret helpers and is typeable (`placeCaretAtOffset` threw `IndexSizeError` when it was a child).

**The CDN link is gone**; the package ships the font.

## Verified

24 marks render, zero unformed ligatures, 25 chevrons at one angle with size-derived stroke, no `appearance: auto` left, `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
